### PR TITLE
Merge 'luke-gumbley:react-virtualized'

### DIFF
--- a/source/InfiniteLoader/InfiniteLoader.jest.js
+++ b/source/InfiniteLoader/InfiniteLoader.jest.js
@@ -175,7 +175,7 @@ describe('InfiniteLoader', () => {
     it('should not interfere with :threshold', () => {
       render(
         getMarkup({
-          minimumBatchSize: 10,
+          minimumBatchSize: 15,
           threshold: 10,
         }),
       );
@@ -263,7 +263,7 @@ describe('InfiniteLoader', () => {
     expect(loadMoreRowsCalls).toEqual([{startIndex: 0, stopIndex: 19}]);
     loadMoreRowsCalls.splice(0);
     innerOnRowsRendered({startIndex: 0, stopIndex: 20});
-    expect(loadMoreRowsCalls).toEqual([{startIndex: 0, stopIndex: 20}]);
+    expect(loadMoreRowsCalls).toEqual([{startIndex: 0, stopIndex: 39}]);
   });
 
   it('resetLoadMoreRowsCache should reset memoized state', () => {

--- a/source/InfiniteLoader/InfiniteLoader.js
+++ b/source/InfiniteLoader/InfiniteLoader.js
@@ -200,45 +200,33 @@ export function scanForUnloadedRanges({
     }
   }
 
+  const isMultiple = range =>
+    !((range.stopIndex - range.startIndex + 1) % minimumBatchSize);
+
   // If :rangeStopIndex is not null it means we haven't ran out of unloaded rows.
-  // Scan forward to try filling our :minimumBatchSize.
+  // Scan forward to try and hit a multiple of our :minimumBatchSize.
   if (rangeStopIndex !== null) {
-    const potentialStopIndex = Math.min(
-      Math.max(rangeStopIndex, rangeStartIndex + minimumBatchSize - 1),
-      rowCount - 1,
-    );
-
-    for (let index = rangeStopIndex + 1; index <= potentialStopIndex; index++) {
-      if (!isRowLoaded({index})) {
-        rangeStopIndex = index;
-      } else {
-        break;
-      }
-    }
-
-    unloadedRanges.push({
+    const range = {
       startIndex: rangeStartIndex,
       stopIndex: rangeStopIndex,
-    });
+    };
+
+    let index = range.stopIndex + 1;
+    while (index < rowCount && !isMultiple(range) && !isRowLoaded({index})) {
+      range.stopIndex = index++;
+    }
+
+    unloadedRanges.push(range);
   }
 
   // Check to see if our first range ended prematurely.
-  // In this case we should scan backwards to try filling our :minimumBatchSize.
+  // In this case we should scan backwards to try and hit a multiple of our :minimumBatchSize.
   if (unloadedRanges.length) {
-    const firstUnloadedRange = unloadedRanges[0];
+    const range = unloadedRanges[0];
 
-    while (
-      firstUnloadedRange.stopIndex - firstUnloadedRange.startIndex + 1 <
-        minimumBatchSize &&
-      firstUnloadedRange.startIndex > 0
-    ) {
-      let index = firstUnloadedRange.startIndex - 1;
-
-      if (!isRowLoaded({index})) {
-        firstUnloadedRange.startIndex = index;
-      } else {
-        break;
-      }
+    let index = range.startIndex - 1;
+    while (index >= 0 && !isMultiple(range) && !isRowLoaded({index})) {
+      range.startIndex = index--;
     }
   }
 


### PR DESCRIPTION
For the first and last unloaded range, instead of accepting any size
over minimumBatchSize, scan forward/backward until reaching a multiple
of minimumBatchSize (if possible). Modify tests to reflect the new
behaviour.

From https://github.com/luke-gumbley/react-virtualized